### PR TITLE
Open links in new tab

### DIFF
--- a/src/components/link/Link.jsx
+++ b/src/components/link/Link.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import "./Link.scss";
 
-const Link = ({ title, url, external, children }) => (
+const Link = ({ title, url, external = true, children }) => (
   // eslint-disable-next-line react/jsx-no-target-blank
   <a
     className="link"


### PR DESCRIPTION
Fixes [#36](https://github.com/darekkay/static-marks/issues/36)
Added a default value to the external prop as it was before [this commit](https://github.com/darekkay/static-marks-app/commit/3e76cb7472a2e2c67da77748cd37b2eb171b16eb#diff-1af62bce814812c01b61d5f5e2b84f98df36edb7250c587e4249f22aba224572L14)